### PR TITLE
The lbry api changed...

### DIFF
--- a/background.js
+++ b/background.js
@@ -83,7 +83,7 @@ function validateVideo (id) {
 	  let title = data.data.videos[id]
 	  
 	 if (title != null) {
-		let url =  "https://lbry.tv/" + title
+		let url =  "https://lbry.tv/" + title.replace(/^lbry:\/\//, "").replace(/#/g, ":");
 		chrome.tabs.update({url: url});
 	 }
    });


### PR DESCRIPTION
the lbry api changed the format that they return in `https://api.lbry.com/yt/resolve?video_ids=` to be a valid lbry url, i.e. `"lbry://@Lunduke#e/lbry-the-viable-youtube-alternative-in#4"`. This was causing the `__` error.

This pr adds support for the new format