### PR TITLE
Fix typos and missing quotes in input.

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -19,8 +19,8 @@
 </div>
 
 
-<label> Another usefull tools: </label>
-<button type="button" class="btn1" id="btn1">Subscribtions Converter</button>
+<label> Another useful tools: </label>
+<button type="button" class="btn1" id="btn1">Subscriptions Converter</button>
 
 
 </div>

--- a/tools/YTtoLBRY.html
+++ b/tools/YTtoLBRY.html
@@ -3,14 +3,14 @@
   <head>
     <link rel="stylesheet" href="YTtoLBRY.css" />
     <meta charset="utf-8">
-    <title>Subscribtion Converter</title>
+    <title>Subscription Converter</title>
     <script src="YTtoLBRY.js" charset="utf-8"></script>
   </head>
   <body>
     <iframe width="560" height="315" src="https://lbry.tv/$/embed/howtouseconverter/c9827448d6ac7a74ecdb972c5cdf9ddaf648a28e" allowfullscreen></iframe>
     <label for="file">Select Youtube Subscriptions</label>
     <input type="file" id="subconv" class=PickFile>
-    <input type="button" id="go-button" value="GO" class=goButton >
+    <input type="button" id="go-button" value="GO" class="goButton"/>
     <ul id="lbry-channel-list">
     </ul>
     <script type="text/javascript" src="content.js"></script>


### PR DESCRIPTION
Hi,
I noticed a couple of typos.
I downloaded this extension from Firefox store and when I click "Go" button nothing happens.
Maybe it's because quotes in class in 'input' was missing.
If it will not fix the problem, I will create separate issue for it.