### PR TITLE
Use `location.replace` to for seamless redirect

### DIFF
--- a/scripts/tabOnUpdated.js
+++ b/scripts/tabOnUpdated.js
@@ -54,7 +54,9 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
       } else if (redirect === "app") {
         newUrl = `lbry://${title.replace(/^lbry:\/\//, "")}`;
       }
-      chrome.tabs.update(tabId, { url: newUrl });
+      chrome.tabs.executeScript(tabId, {
+        code: `location.replace("${newUrl}")`
+      });
     });
   });
 });


### PR DESCRIPTION
Hello, this is to close #27 

This approach injects JS to call `location.replace` which removes the original YouTube video entry.

This approach is a bit of a hack, though. I'm thinking that the better approach here would have been to use the webRequest API; however, this would require reworking the entire redirect mechanism used and be outside the scope of this issue.