### PR TITLE
Github Action to Build

### DIFF
--- a/.github/workflows/extension-build.js.yml
+++ b/.github/workflows/extension-build.js.yml
@@ -1,0 +1,36 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [15.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn
+    - run: npm run build
+    - run: npm run build:webext
+    - name: Archive extension directory
+      uses: actions/upload-artifact@v2
+      with:
+        name: extension
+        path: |
+          dist
+          web-ext-artifacts

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For Production
 ```bash
 $ npm install
 $ npm run build
-$ npx web-ext build --source-dir ./dist  # optional, to create the zip file from the dist directory
+$ npm run build:webext  # optional, to create the zip file from the dist directory
 ```
 
 For Development

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "watch:assets": "cpx --watch -v \"src/**/*.{json,png,svg}\" dist/",
     "build:parcel": "cross-env NODE_ENV=production parcel build --no-source-maps --no-minify \"src/scripts/*.{js,ts}\" \"src/**/*.html\"",
     "watch:parcel": "parcel watch --no-hmr --no-source-maps \"src/scripts/*.{js,jsx,ts,tsx}\" \"src/**/*.html\"",
+    "build:webext": "web-ext build --source-dir ./dist --overwrite-dest",
     "build": "npm-run-all -l -p build:parcel build:assets",
     "watch": "npm-run-all -l -p watch:parcel watch:assets",
     "start:chrome": "web-ext run -t chromium --source-dir ./dist",


### PR DESCRIPTION
We can further expand this later to also run tests (as soon as we write those) but this should make the main repository automatically build the project whenever there's a PR and then create artifacts with the contents of the extension.

This should make it convenient to test and publish in the future.