### PR TITLE
Fix CORS errors in content script

### DIFF
--- a/src/scripts/tabOnUpdated.ts
+++ b/src/scripts/tabOnUpdated.ts
@@ -1,5 +1,36 @@
-import { appRedirectUrl } from '../common/lbry-url';
-import { getSettingsAsync } from '../common/settings';
+import { appRedirectUrl, parseProtocolUrl } from '../common/lbry-url';
+import { getSettingsAsync, LbrySettings } from '../common/settings';
+import { YTDescriptor, ytService } from '../common/yt';
+export interface UpdateContext {
+  descriptor: YTDescriptor
+  /** LBRY URL fragment */
+  url: string
+  enabled: boolean
+  redirect: LbrySettings['redirect']
+}
+
+async function resolveYT(descriptor: YTDescriptor) {
+  const lbryProtocolUrl: string | null = await ytService.resolveById(descriptor).then(a => a[0]);
+  const segments = parseProtocolUrl(lbryProtocolUrl || '', { encode: true });
+  if (segments.length === 0) return;
+  return segments.join('/');
+}
+
+const urlCache: Record<string, string | undefined> = {};
+
+async function ctxFromURL(url: string): Promise<UpdateContext | void> {
+  if (!url || !(url.startsWith('https://www.youtube.com/watch?v=') || url.startsWith('https://www.youtube.com/channel/'))) return;
+  url = new URL(url).href;
+  const { enabled, redirect } = await getSettingsAsync('enabled', 'redirect');
+  const descriptor = ytService.getId(url);
+  if (!descriptor) return; // couldn't get the ID, so we're done
+
+  const res = url in urlCache ? urlCache[url] : await resolveYT(descriptor);
+  urlCache[url] = res;
+  if (!res) return; // couldn't find it on lbry, so we're done
+
+  return { descriptor, url: res, enabled, redirect };
+}
 
 // handles lbry.tv -> lbry app redirect
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, { url: tabUrl }) => {
@@ -21,9 +52,16 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, { url: tabUrl }) => 
   });
 });
 
+chrome.runtime.onMessage.addListener(({ url }: { url: string }, sender, sendResponse) => {
+  ctxFromURL(url).then(ctx => {
+    sendResponse(ctx);
+  })
+  return true;
+})
+
 // relay youtube link changes to the content script
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, { url }) => {
-  if (!changeInfo.url || !url ||
-    !(url.startsWith('https://www.youtube.com/watch?v=') || url.startsWith('https://www.youtube.com/channel/'))) return;
-  chrome.tabs.sendMessage(tabId, { url });
+  if (!changeInfo.url || !url || !(url.startsWith('https://www.youtube.com/watch?v=') || url.startsWith('https://www.youtube.com/channel/'))) return;
+
+  ctxFromURL(url).then(ctx => chrome.tabs.sendMessage(tabId, ctx));
 });


### PR DESCRIPTION
Move fetch requests to background page. Include a dirty cache so that same requests don't get made over and over again as settings change.

This should fix #56 