### PR TITLE
Caching changes for URL resolver APIs

### DIFF
--- a/src/common/yt.ts
+++ b/src/common/yt.ts
@@ -61,11 +61,10 @@ const URLResolverCache = (() =>
       const expireAtCursorRequest = transaction.objectStore("store").index("expireAt").openCursor(range)
       expireAtCursorRequest.addEventListener('success', () =>
       {
-        const timestampCursor = expireAtCursorRequest.result
-        if (!timestampCursor) return
-        console.log("deleting: " + timestampCursor)
-        timestampCursor.delete()
-        timestampCursor.continue()
+        const expireCursor = expireAtCursorRequest.result
+        if (!expireCursor) return
+        expireCursor.delete()
+        expireCursor.continue()
       })
     })
   }
@@ -76,9 +75,7 @@ const URLResolverCache = (() =>
     return await new Promise((resolve, reject) =>
     {
       const db = openRequest.result
-      console.log('new put!')
       if (!db) return resolve()
-      console.log('new put')
       const store = db.transaction("store", "readwrite").objectStore("store")
       const putRequest = store.put({ value: url, expireAt: new Date(Date.now() + 24 * 60 * 60 * 1000) }, id)
       putRequest.addEventListener('success', () => resolve())
@@ -265,10 +262,11 @@ export const ytService = {
                 .filter((descriptorId) => descriptorId)
                 .join(urlResolverFunction.paramArraySeperator)
               )
+
               const apiResponse = await fetch(url.toString(), { cache: 'no-store' });
               if (!apiResponse.ok) break
               const values = followResponsePath<string[]>(await apiResponse.json(), urlResolverFunction.responsePath)
-              console.log('hellooo')
+
               await Promise.all(values.map(async (value, index) => {
                 const descriptor = descriptorsGroup[index]
                 if (value) results[descriptor.index] = value

--- a/src/common/yt.ts
+++ b/src/common/yt.ts
@@ -106,7 +106,7 @@ export const ytService = {
     if (channelId) return { id: channelId, type: 'channel' };
     return null;
   },
-
+ 
   /**
   * @param descriptorsWithIndex YT resource IDs to check
   * @returns a promise with the list of channels that were found on lbry
@@ -163,7 +163,7 @@ export const ytService = {
               if (!descriptor.id) break
               url.searchParams.set(urlResolverFunction.paramName, descriptor.id)
   
-              const apiResponse = await fetch(url.toString(), { cache: 'force-cache' });
+              const apiResponse = await fetch(url.toString(), { cache: 'reload' });
               if (!apiResponse.ok) break
               const value = followResponsePath<string>(await apiResponse.json(), urlResolverFunction.responsePath)
               if (value) results[descriptor.index] = value
@@ -184,7 +184,7 @@ export const ytService = {
                 .filter((descriptorId) => descriptorId)
                 .join(urlResolverFunction.paramArraySeperator)
               )
-              const apiResponse = await fetch(url.toString(), { cache: 'force-cache' });
+              const apiResponse = await fetch(url.toString(), { cache: 'reload' });
               if (!apiResponse.ok) break
               const values = followResponsePath<string[]>(await apiResponse.json(), urlResolverFunction.responsePath)
               values.forEach((value, index) => {

--- a/src/scripts/tabOnUpdated.ts
+++ b/src/scripts/tabOnUpdated.ts
@@ -16,20 +16,25 @@ async function resolveYT(descriptor: YtIdResolverDescriptor) {
   return segments.join('/');
 }
 
+const ctxFromURLIdCache: Record<string, Promise<string | undefined>> = {}
 async function ctxFromURL(href: string): Promise<UpdateContext | void> {
   if (!href) return;
-
+  
   const url = new URL(href);
   if (!getSourcePlatfromSettingsFromHostname(url.hostname)) return
   if (!(url.pathname.startsWith('/watch') || url.pathname.startsWith('/channel'))) return
 
-  const { redirect, targetPlatform } = await getExtensionSettingsAsync('redirect', 'targetPlatform');
   const descriptor = ytService.getId(href);
   if (!descriptor) return; // couldn't get the ID, so we're done
 
-  const res = await resolveYT(descriptor); // NOTE: API call cached by the browser
+  // NOTE: API call cached by the browser for the future version
+  // But cache busting is active for now
+  // Manual memory cache will be removed later
+  const promise = ctxFromURLIdCache[descriptor.id] ?? (ctxFromURLIdCache[descriptor.id] = resolveYT(descriptor))
+  const res = await promise;
   if (!res) return; // couldn't find it on lbry, so we're done
 
+  const { redirect, targetPlatform } = await getExtensionSettingsAsync('redirect', 'targetPlatform');
   return { descriptor, lbryPathname: res, redirect, targetPlatform };
 }
 

--- a/src/scripts/tabOnUpdated.ts
+++ b/src/scripts/tabOnUpdated.ts
@@ -16,7 +16,6 @@ async function resolveYT(descriptor: YtIdResolverDescriptor) {
   return segments.join('/');
 }
 
-const ctxFromURLIdCache: Record<string, Promise<string | undefined>> = {}
 async function ctxFromURL(href: string): Promise<UpdateContext | void> {
   if (!href) return;
   
@@ -27,11 +26,8 @@ async function ctxFromURL(href: string): Promise<UpdateContext | void> {
   const descriptor = ytService.getId(href);
   if (!descriptor) return; // couldn't get the ID, so we're done
 
-  // NOTE: API call cached by the browser for the future version
-  // But cache busting is active for now
-  // Manual memory cache will be removed later
-  const promise = ctxFromURLIdCache[descriptor.id] ?? (ctxFromURLIdCache[descriptor.id] = resolveYT(descriptor))
-  const res = await promise;
+  // NOTE: API call cached by resolveYT method automatically
+  const res = await resolveYT(descriptor);
   if (!res) return; // couldn't find it on lbry, so we're done
 
   const { redirect, targetPlatform } = await getExtensionSettingsAsync('redirect', 'targetPlatform');

--- a/src/scripts/tabOnUpdated.ts
+++ b/src/scripts/tabOnUpdated.ts
@@ -16,6 +16,7 @@ async function resolveYT(descriptor: YtIdResolverDescriptor) {
   return segments.join('/');
 }
 
+const ctxFromURLOnGoingPromise: Record<string, Promise<UpdateContext | void>> = {}
 async function ctxFromURL(href: string): Promise<UpdateContext | void> {
   if (!href) return;
   
@@ -26,12 +27,18 @@ async function ctxFromURL(href: string): Promise<UpdateContext | void> {
   const descriptor = ytService.getId(href);
   if (!descriptor) return; // couldn't get the ID, so we're done
 
-  // NOTE: API call cached by resolveYT method automatically
-  const res = await resolveYT(descriptor);
-  if (!res) return; // couldn't find it on lbry, so we're done
+  // Don't create a new Promise for same ID until on going one is over.
+  const promise = ctxFromURLOnGoingPromise[descriptor.id] ?? (ctxFromURLOnGoingPromise[descriptor.id] = (async () => {
+    // NOTE: API call cached by resolveYT method automatically
+    const res = await resolveYT(descriptor)
+    if (!res) return // couldn't find it on lbry, so we're done
 
-  const { redirect, targetPlatform } = await getExtensionSettingsAsync('redirect', 'targetPlatform');
-  return { descriptor, lbryPathname: res, redirect, targetPlatform };
+    const { redirect, targetPlatform } = await getExtensionSettingsAsync('redirect', 'targetPlatform')
+    return { descriptor, lbryPathname: res, redirect, targetPlatform }
+  })())
+  await promise
+  delete ctxFromURLOnGoingPromise[descriptor.id]
+  return await promise
 }
 
 // handles lbry.tv -> lbry app redirect


### PR DESCRIPTION
- Added back manual memory cache temporarily
- And this time its working as expected
- Also disabled use of browser cache for now
- Thought we are still saying browser to cache it for the future version

