### PR TITLE
Changed cache time

### DIFF
--- a/src/common/yt/urlCache.ts
+++ b/src/common/yt/urlCache.ts
@@ -52,7 +52,7 @@ async function put(url: string | null, id: string): Promise<void> {
     return await new Promise((resolve, reject) => {
         const store = db?.transaction("store", "readwrite").objectStore("store")
         if (!store) return resolve()
-        const request = store.put({ value: url, expireAt: new Date(Date.now() + 24 * 60 * 60 * 1000) }, id)
+        const request = store.put({ value: url, expireAt: !url ? new Date(Date.now() + 1 * 60 * 60 * 1000) : new Date(Date.now() + 15 * 24 * 60 * 60 * 1000) }, id)
         request.addEventListener('success', () => resolve())
         request.addEventListener('error', () => reject(request.error))
     })


### PR DESCRIPTION
# How was it before?
We were caching all of the responses for 24 hours.

# How it's now?
- If we didn't find the lbry url, we cache the response for 1 hour.
- If we found the lbry url, we cache the response for 15 days.