### PR TITLE
Added timeout to resolver API request

### DIFF
--- a/src/modules/yt/urlResolve.ts
+++ b/src/modules/yt/urlResolve.ts
@@ -53,7 +53,12 @@ export async function resolveById(params: Paramaters, progressCallback?: (progre
                 publicKey
             }))
 
-        const apiResponse = await fetch(url.toString(), { cache: 'no-store' })
+        const controller = new AbortController()
+        // 5 second timeout:
+        const timeoutId = setTimeout(() => controller.abort(), 5000)
+        const apiResponse = await fetch(url.toString(), { cache: 'no-store', signal: controller.signal })
+        clearTimeout(timeoutId)
+        
         if (apiResponse.ok) {
             const response: ApiResponse = await apiResponse.json()
             for (const item of params) {


### PR DESCRIPTION
When one of the APIs is down, for example `Madiator Finder API`, even if i change it to `Odysee API` from settings, it doesnt take effect for a long while.

Because if we get multiple requests with the same parameters while the first one is still running, instead of running the request function multiple times, we just run it once, and send the same result to all promises.

So even if i change the resolver API to `Odysee` from settings, it waits until the first `Finder API` request timeouts.

So it stucks for a while, so I added 5 seconds timeout.